### PR TITLE
callgraph: make pre-push target pass with newer pandas versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2019 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# SPDX-FileCopyrightText: 2022 Henri Rosten
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
@@ -25,6 +26,7 @@ matrix:
       before_install:
         - cd development-process/stable-maintenance/regression-analysis/
       install:
+        - pip install --upgrade importlib_metadata
         - make install-requirements
       script:
         - make pre-push

--- a/development-process/stable-maintenance/regression-analysis/badfixstats.py
+++ b/development-process/stable-maintenance/regression-analysis/badfixstats.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2019 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# SPDX-FileCopyrightText: 2022 Henri Rosten
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
@@ -741,7 +742,7 @@ if __name__ == "__main__":
     nomerges = args.no_merge_datapoints
 
     repo = repo if repo.endswith(".git") else os.path.join(repo, ".git")
-    if(not (os.path.isdir(repo))):
+    if (not (os.path.isdir(repo))):
         sys.stderr.write("Error: not a git repository: %s\n" % repo)
         sys.exit(1)
 

--- a/development-process/stable-maintenance/regression-analysis/update.py
+++ b/development-process/stable-maintenance/regression-analysis/update.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2019 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# SPDX-FileCopyrightText: 2022 Henri Rosten
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
@@ -296,7 +297,7 @@ if __name__ == "__main__":
     gitdir = args.git_dir
 
     gitdir = gitdir if gitdir.endswith(".git") else os.path.join(gitdir, ".git")
-    if(not (os.path.isdir(gitdir))):
+    if (not (os.path.isdir(gitdir))):
         sys.stderr.write("Error: not a git repository: %s\n" % gitdir)
         sys.exit(1)
 

--- a/safety-architecture/tools/callgraph-tool/scripts/query_callgraph.py
+++ b/safety-architecture/tools/callgraph-tool/scripts/query_callgraph.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: 2020 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# SPDX-FileCopyrightText: 2022 Henri Rosten
 #
 # SPDX-License-Identifier: Apache-2.0
 import argparse
@@ -36,8 +37,8 @@ class CallGraphFilter():
         self.callee_line = callee_line
 
     def get_query_str(self):
-        return ' & '.join(
-            ["{}=='{}'".format(key, value)
+        return ' and '.join(
+            ["{} == '{}'".format(key, value)
              for key, value in self.__dict__.items() if value is not None])
 
     def __eq__(self, other):
@@ -137,7 +138,7 @@ class Grapher():
 
     def _load_callgraph_data(self, filename):
         utils.exit_unless_accessible(filename)
-        self.df = pd.read_csv(filename, na_values=[''], keep_default_na=False)
+        self.df = pd.read_csv(filename, dtype=str, keep_default_na=False)
         self.df.reset_index(drop=True, inplace=True)
         self.df.columns = self.df.columns.str.lower()
         require_cols = [
@@ -466,7 +467,7 @@ def node_id(filename, function, line):
     return ("%s_%s_%s" % (
         filename,
         html.escape(str(function)),
-        float(line)
+        str(line)
     )).replace(":", "")
 
 

--- a/safety-architecture/tools/callgraph-tool/tests/test_crix_callgraph.py
+++ b/safety-architecture/tools/callgraph-tool/tests/test_crix_callgraph.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: 2020 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# SPDX-FileCopyrightText: 2022 Henri Rosten
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -53,9 +54,9 @@ def set_up_session_test_data(request):
     # Run once at the start of test session, before any tests have been run
     print("session setup")
     clang_path = get_clang_bin_path()
-    assert(Path(clang_path).exists())
+    assert Path(clang_path).exists()
     clang_version = get_clang_version()
-    assert(clang_version)
+    assert clang_version
     request.addfinalizer(clean_up_session_test_data)
     assert Path(CG_BIN).exists()
     # Generate target bitcode files

--- a/safety-architecture/tools/callgraph-tool/tests/test_utils.py
+++ b/safety-architecture/tools/callgraph-tool/tests/test_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: 2020 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# SPDX-FileCopyrightText: 2022 Henri Rosten
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -28,6 +29,7 @@ def df_to_string(df):
 
 
 def df_difference(df_left, df_right):
+    df_right = df_right.astype(df_left.dtypes.to_dict())
     df = df_left.merge(
         df_right,
         how='outer',


### PR DESCRIPTION
- Read all callgraph csv fields as strings to match queries also in cases where datatypes might not match
- Fix warnings reported by newer pycodestyle versions
- Fix build error with travis on python 3.7, reference: https://travis-ci.community/t/build-error-for-python-3-7-on-two-different-projects/12895

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>